### PR TITLE
Support multiple hostnames

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jojonas/db_nmap
 
-go 1.17
+go 1.18
 
 require (
 	github.com/jackc/pgx/v4 v4.18.1
@@ -23,6 +23,7 @@ require (
 	github.com/lib/pq v1.10.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	golang.org/x/crypto v0.8.0 // indirect
+	golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 golang.org/x/crypto v0.8.0 h1:pd9TJtTueMTVQXzk8E2XESSMQDj/U7OUu0PqJqPXQjQ=
 golang.org/x/crypto v0.8.0/go.mod h1:mRqEX+O9/h5TFCrQhkgjo2yKi0yYA+9ecGkdQoHrywE=
+golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b h1:r+vk0EmXNmekl0S0BascoeeoHk/L7wmaW2QF90K+kYI=
+golang.org/x/exp v0.0.0-20230801115018-d63ba01acd4b/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=

--- a/internal/msf_db.go
+++ b/internal/msf_db.go
@@ -11,6 +11,8 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+var EnableMultipleHostnames = false
+
 type MsfWorkspace struct {
 	Id          int
 	Name        string
@@ -108,7 +110,14 @@ func InsertHost(db *gorm.DB, workspaceId int, nmapHost NmapHost) (int, error) {
 			msfHost.MAC = allMacs[0].String()
 		}
 
-		msfHost.Name = joinHostnames(msfHost.Name, nmapHost.AllHostnames()...)
+		if EnableMultipleHostnames {
+			msfHost.Name = joinHostnames(msfHost.Name, nmapHost.AllHostnames()...)
+		} else {
+			names := nmapHost.AllHostnames()
+			if len(names) > 0 {
+				msfHost.Name = names[0]
+			}
+		}
 
 		msfHost.State = "alive"
 

--- a/internal/msf_db.go
+++ b/internal/msf_db.go
@@ -220,12 +220,13 @@ func InsertService(db *gorm.DB, hostId int, service NmapService) error {
 func joinHostnames(previousHostnames string, newHostnames ...string) string {
 	var allHostnames []string
 
-	for _, oldHostname := range strings.Split(previousHostnames, ",") {
-		allHostnames = append(allHostnames, strings.ToLower(strings.TrimSpace(oldHostname)))
-	}
+	for _, rawHostname := range append(strings.Split(previousHostnames, ","), newHostnames...) {
+		hostname := strings.ToLower(strings.TrimSpace(rawHostname))
+		if hostname == "" {
+			continue
+		}
 
-	for _, newHostname := range newHostnames {
-		allHostnames = append(allHostnames, strings.ToLower(strings.TrimSpace(newHostname)))
+		allHostnames = append(allHostnames, hostname)
 	}
 
 	slices.Sort(allHostnames)


### PR DESCRIPTION
This PR adds optional support for multiple hostnames. It can be enabled during compilation via `-ldflags "-X main.enableMultipleHostnames=true"` or during runtime with an environment variable (`export DB_NMAP_ENABLE_MULTIPLE_HOSTNAMES=1`). If a host has multiple hostnames they will be joined with a colon like this: `hostname1, hostname2`

The PR also adds a missing error check.