### PR TITLE
Do not set nullable fields to zero values

### DIFF
--- a/internal/msf_db.go
+++ b/internal/msf_db.go
@@ -27,14 +27,14 @@ type MsfHost struct {
 	WorkspaceId int
 	Address     string
 
-	MAC     string
-	Name    string
-	State   string
-	OSName  string
-	Purpose string
+	MAC     string `gorm:"default:null"`
+	Name    string `gorm:"default:null"`
+	State   string `gorm:"default:null"`
+	OSName  string `gorm:"default:null"`
+	Purpose string `gorm:"default:null"`
 
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	CreatedAt time.Time `gorm:"default:null"`
+	UpdatedAt time.Time `gorm:"default:null"`
 }
 
 func (MsfHost) TableName() string {
@@ -43,14 +43,14 @@ func (MsfHost) TableName() string {
 
 type MsfService struct {
 	Id        int
-	HostId    int
-	CreatedAt time.Time
+	HostId    int       `gorm:"default:null"`
+	CreatedAt time.Time `gorm:"default:null"`
 	Port      int
 	Proto     string
-	State     string
-	Name      string
-	UpdatedAt time.Time
-	Info      string
+	State     string    `gorm:"default:null"`
+	Name      string    `gorm:"default:null"`
+	UpdatedAt time.Time `gorm:"default:null"`
+	Info      string    `gorm:"default:null"`
 }
 
 func (MsfService) TableName() string {
@@ -170,7 +170,6 @@ func InsertService(db *gorm.DB, hostId int, service NmapService) error {
 		).
 		FirstOrCreate(&msfService).
 		Error
-
 	if err != nil {
 		return fmt.Errorf("query service %v: %w", service, err)
 	}


### PR DESCRIPTION
According to the database schema, most fields of the `hosts` and `services` tables are nullable:

```sql
> SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = 'hosts';
      column_name      |          data_type          | is_nullable 
-----------------------+-----------------------------+-------------
 id                    | integer                     | NO
 created_at            | timestamp without time zone | YES
 address               | inet                        | NO
 workspace_id          | integer                     | NO
 updated_at            | timestamp without time zone | YES
 note_count            | integer                     | YES
 vuln_count            | integer                     | YES
 service_count         | integer                     | YES
 host_detail_count     | integer                     | YES
 exploit_attempt_count | integer                     | YES
 cred_count            | integer                     | YES
 arch                  | character varying           | YES
 detected_arch         | character varying           | YES
 os_family             | character varying           | YES
 purpose               | text                        | YES
 info                  | character varying           | YES
 comments              | text                        | YES
 scope                 | text                        | YES
 virtual_host          | text                        | YES
 mac                   | character varying           | YES
 comm                  | character varying           | YES
 name                  | character varying           | YES
 state                 | character varying           | YES
 os_name               | character varying           | YES
 os_flavor             | character varying           | YES
 os_sp                 | character varying           | YES
 os_lang               | character varying           | YES

> SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = 'services';
 column_name |          data_type          | is_nullable 
-------------+-----------------------------+-------------
 created_at  | timestamp without time zone | YES
 port        | integer                     | NO
 updated_at  | timestamp without time zone | YES
 id          | integer                     | NO
 host_id     | integer                     | YES
 info        | text                        | YES
 proto       | character varying           | NO
 state       | character varying           | YES
 name        | character varying           | YES
```

Currently, `db_nmap` inserts Go's zero values if a field is not set. This PR adds struct tags that change this behavior.

